### PR TITLE
Add gravity and ground plane

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "cannon-es": "^0.20.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "three": "^0.178.0"
@@ -2248,6 +2249,12 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cannon-es": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/cannon-es/-/cannon-es-0.20.0.tgz",
+      "integrity": "sha512-eZhWTZIkFOnMAJOgfXJa9+b3kVlvG+FX4mdkpePev/w/rP5V8NRquGyEozcjPfEoXUlb+p7d9SUcmDSn14prOA==",
+      "license": "MIT"
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "cannon-es": "^0.20.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "three": "^0.178.0"


### PR DESCRIPTION
## Summary
- add `cannon-es` physics library
- implement physics world with gravity and a plane
- drop dice onto the plane using physics
- update lighting and camera position

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68806fb9e7b48329a1c858a36f6d01c5