### PR TITLE
Add trigger state with button in App

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,22 @@
+import { useState } from 'react'
 import DiceCanvas from './DiceCanvas'
 import './App.css'
 
 function App() {
+  const [trigger, setTrigger] = useState(0)
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-800 text-white">
       <h1 className="text-3xl mb-4">Three.js Dice</h1>
+      <button
+        type="button"
+        className="mb-4 px-4 py-2 bg-blue-600 rounded"
+        onClick={() => setTrigger((t) => t + 1)}
+      >
+        Roll Dice
+      </button>
       <div className="w-80 h-80">
-        <DiceCanvas />
+        <DiceCanvas trigger={trigger} />
       </div>
     </div>
   )

--- a/frontend/src/DiceCanvas.jsx
+++ b/frontend/src/DiceCanvas.jsx
@@ -25,7 +25,7 @@ function createDice() {
   return new THREE.Mesh(geometry, materials)
 }
 
-export default function DiceCanvas() {
+export default function DiceCanvas({ trigger }) {
   const mountRef = useRef(null)
 
   useEffect(() => {
@@ -127,6 +127,10 @@ export default function DiceCanvas() {
       renderer.dispose()
     }
   }, [])
+
+  useEffect(() => {
+    console.log('trigger', trigger)
+  }, [trigger])
 
   return <div ref={mountRef} className="w-full h-full" />
 }


### PR DESCRIPTION
## Summary
- add a `trigger` state in `App.jsx`
- add button to update state and pass it to `DiceCanvas`
- accept `trigger` prop in `DiceCanvas` and log changes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880728772708329ae0d4c9b827a27f5